### PR TITLE
Average salary succesfully displayed with template literal

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -65,6 +65,11 @@ const collectEmployees = function() {
 // Display the average salary
 const displayAverageSalary = function(employeesArray) {
   // TODO: Calculate and display the average salary
+  let total = 0;
+  for (let i = 0; i < employeesArray.length; i++) {
+    total = total + employeesArray[i].salary;
+  } 
+  console.log(`The average employee salary between our ${employeesArray.length} employee(s) is $${(total/employeesArray.length).toFixed(2)}`)
 }
 
 // Select a random employee


### PR DESCRIPTION
Inside function 'displayAverageSalary' is a variable 'total' and a for loop that runs the length of the employees array and adds the salary of each emplyee to the total.

Then the console log uses a template literal string to log the following 'The average employee salary between our ${employeesArray.length} employee(s) is $${(total/employeesArray.length).toFixed(2)}'.

Instead of using memory on a average variable I simply did the equation inside the log and used 'toFixed' to display only the last two digits of the average.

